### PR TITLE
クエリ文字列を指定して検索するAPIを実装

### DIFF
--- a/src/main/java/com/tutorial/nameservice/NameController.java
+++ b/src/main/java/com/tutorial/nameservice/NameController.java
@@ -17,6 +17,6 @@ public class NameController {
 
     @GetMapping("/names")
     public List<Name> findByNames(@RequestParam String startsWith) {
-        return nameMapper.findByNameStartingWith(startsWith);
+        return nameMapper.findByNamestartsWith(startsWith);
     }
 }

--- a/src/main/java/com/tutorial/nameservice/NameController.java
+++ b/src/main/java/com/tutorial/nameservice/NameController.java
@@ -1,6 +1,7 @@
 package com.tutorial.nameservice;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -15,8 +16,7 @@ public class NameController {
     }
 
     @GetMapping("/names")
-    public List<Name> getNames() {
-        List<Name> names = nameMapper.findAll();
-        return names;
+    public List<Name> findByNames(@RequestParam String startsWith) {
+        return nameMapper.findByNameStartingWith(startsWith);
     }
 }

--- a/src/main/java/com/tutorial/nameservice/NameController.java
+++ b/src/main/java/com/tutorial/nameservice/NameController.java
@@ -17,6 +17,6 @@ public class NameController {
 
     @GetMapping("/names")
     public List<Name> findByNames(@RequestParam String startsWith) {
-        return nameMapper.findByNamestartsWith(startsWith);
+        return nameMapper.findByNameStartsWith(startsWith);
     }
 }

--- a/src/main/java/com/tutorial/nameservice/NameMapper.java
+++ b/src/main/java/com/tutorial/nameservice/NameMapper.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Mapper
 public interface NameMapper {
 
-    @Select("SELECT * FROM names")
-    List<Name> findAll();
+
+    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
+    List<Name> findByNameStartingWith(String prefix);
 }

--- a/src/main/java/com/tutorial/nameservice/NameMapper.java
+++ b/src/main/java/com/tutorial/nameservice/NameMapper.java
@@ -11,5 +11,5 @@ public interface NameMapper {
 
 
     @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
-    List<Name> findByNameStartingWith(String prefix);
+    List<Name> findByNamestartsWith(String prefix);
 }

--- a/src/main/java/com/tutorial/nameservice/NameMapper.java
+++ b/src/main/java/com/tutorial/nameservice/NameMapper.java
@@ -11,5 +11,5 @@ public interface NameMapper {
 
 
     @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
-    List<Name> findByNamestartsWith(String prefix);
+    List<Name> findByNameStartsWith(String prefix);
 }


### PR DESCRIPTION
# 概要
## クエリ文字列を指定して検索するAPIを実装しました。


# 動作確認
- startsWith=yと指定した際に一致した名前のみ出力される事を確認。
- startsWith=tと変更した際に一致した名前のみ出力される事を確認。
- 最後にDBにないstartsWith=zと入力した際に空の配列になる事を確認。
- 全てのステータスコードが200になっていることを確認。
- JSON形式でのレスポンスになっていることを確認。

<img width="914" alt="スクリーンショット 2024-09-11 2 42 48" src="https://github.com/user-attachments/assets/70c97b2e-65d7-498d-aee5-4bfb8758afc6">

<img width="897" alt="スクリーンショット 2024-09-11 2 39 58" src="https://github.com/user-attachments/assets/3ae482a1-e048-4193-a1fa-5ea4aa7e4ffe">

<img width="900" alt="スクリーンショット 2024-09-11 2 43 42" src="https://github.com/user-attachments/assets/603cd03f-ea98-4a15-92ee-9ddd32e121a9">


